### PR TITLE
90% TENT-752 Make provider constants match pkgcloud.

### DIFF
--- a/src/Manifesto/common.inc.php
+++ b/src/Manifesto/common.inc.php
@@ -6,5 +6,5 @@ define('FORMAT_ZIP', 'zip');
 define('FORMAT_TARGZ', 'targz');
 define('FORMAT_TARBZ', 'tarbz');
 
-define('FILE_TYPE_S3', 's3');
-define('FILE_TYPE_CF', 'cloudfiles');
+define('FILE_TYPE_S3', 'amazon');
+define('FILE_TYPE_CF', 'rackspace');


### PR DESCRIPTION
Manifesto is using pkgcloud to download files. Our contants ("s3", "cloudfiles") do not match the constants used by pkgcloud.

Pull request: https://github.com/talis/manifesto-server/pull/11 proposed possibly mapping the constants, but it was agreed to make them match.
